### PR TITLE
VER-4826-pipeline-fix: Scala 3 migration - adjustment for controllers

### DIFF
--- a/app/uk/gov/hmrc/partnershipidentification/featureswitch/api/controllers/FeatureSwitchApiController.scala
+++ b/app/uk/gov/hmrc/partnershipidentification/featureswitch/api/controllers/FeatureSwitchApiController.scala
@@ -16,9 +16,8 @@
 
 package uk.gov.hmrc.partnershipidentification.featureswitch.api.controllers
 
-import play.api.Configuration
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, InjectedController}
+import play.api.mvc.{Action, AnyContent, ControllerComponents, InjectedController}
 import uk.gov.hmrc.partnershipidentification.featureswitch.api.services.FeatureSwitchService
 import uk.gov.hmrc.partnershipidentification.featureswitch.core.config.FeatureSwitching
 import uk.gov.hmrc.partnershipidentification.featureswitch.core.models.FeatureSwitchSetting
@@ -26,9 +25,10 @@ import uk.gov.hmrc.partnershipidentification.featureswitch.core.models.FeatureSw
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class FeatureSwitchApiController @Inject()(config: Configuration,
-                                           featureSwitchService: FeatureSwitchService
+class FeatureSwitchApiController @Inject()(featureSwitchService: FeatureSwitchService, controllerComponents: ControllerComponents
                                           ) extends InjectedController with FeatureSwitching {
+  setControllerComponents(controllerComponents)
+
   def getFeatureSwitches(): Action[AnyContent] = Action {
     Ok(Json.toJson(featureSwitchService.getFeatureSwitches()))
   }

--- a/app/uk/gov/hmrc/partnershipidentification/testonly/PartnershipKnownFactsStubController.scala
+++ b/app/uk/gov/hmrc/partnershipidentification/testonly/PartnershipKnownFactsStubController.scala
@@ -17,13 +17,15 @@
 package uk.gov.hmrc.partnershipidentification.testonly
 
 import play.api.libs.json.{JsObject, Json}
-import play.api.mvc.{Action, AnyContent, InjectedController}
+import play.api.mvc.{Action, AnyContent, ControllerComponents, InjectedController}
 
-import javax.inject.Singleton
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 
 @Singleton
-class PartnershipKnownFactsStubController extends InjectedController {
+class PartnershipKnownFactsStubController @Inject() (controllerComponents: ControllerComponents) extends InjectedController {
+
+  setControllerComponents(controllerComponents)
 
   def getPartnershipKnownFacts(sautr: String): Action[AnyContent] = Action.async {
     Future.successful(sautr match {


### PR DESCRIPTION
Ticket connected to:

[VER-4826](https://jira.tools.tax.service.gov.uk/browse/VER-4826) - partnership-identification : Scala 3 update ticket

introduced due to the failing ui-tests with the Scala 3 changes. 


- [x] partnership-identification ui-tests - passed locally

<img width="1340" height="614" alt="image" src="https://github.com/user-attachments/assets/e44b5456-6cd9-4ea7-8256-79127a23e31a" />



- [ ] partnership-identification unit tests - passed locally

<img width="1251" height="248" alt="image" src="https://github.com/user-attachments/assets/96a21ce2-ba35-4915-97de-8a7cb59eb603" />



- [x] partnership-identification integration tests - passed locally

<img width="1362" height="418" alt="image" src="https://github.com/user-attachments/assets/7eef123f-f745-4496-bcbf-81a7c1151424" />
